### PR TITLE
Helper method to load data into sheet

### DIFF
--- a/src/Simplexcel/Worksheet.cs
+++ b/src/Simplexcel/Worksheet.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 namespace Simplexcel
 {
@@ -52,6 +55,53 @@ namespace Simplexcel
             }
 
             Name = name;
+        }
+
+        /// <summary>
+        /// Populate Worksheet with the provided data
+        /// </summary>
+        /// <param name="data"></param>
+        public void Populate<T>(IEnumerable<T> data) where T : class
+        {
+            int row = 0;
+            int col = 0;
+
+            var props = typeof(T).GetTypeInfo().DeclaredProperties
+                .Where(p => p.GetIndexParameters().Length == 0)
+                .Where(p => p.PropertyType.GetTypeInfo().IsValueType || p.PropertyType == typeof(string));
+
+            foreach (var prop in props)
+            {
+                Cells[row, col++] = prop.Name;
+            }
+
+            foreach (var item in data)
+            {
+                row++;
+                col = 0;
+
+                foreach (var prop in props)
+                {
+                    Cell cell;
+
+                    object val = prop.GetValue(item);
+
+                    if (val is sbyte || val is short || val is int || val is long || val is byte || val is uint || val is ushort || val is ulong)
+                    {
+                        cell = new Cell(CellType.Number, Convert.ToDecimal(val), BuiltInCellFormat.NumberNoDecimalPlaces);
+                    }
+                    else if (val is float || val is double || val is decimal)
+                    {
+                        cell = new Cell(CellType.Number, Convert.ToDecimal(val), BuiltInCellFormat.General);
+                    }
+                    else
+                    {
+                        cell = new Cell(CellType.Text, (val ?? String.Empty).ToString(), BuiltInCellFormat.Text);
+                    }
+
+                    Cells[row, col++] = cell;
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This helper method is useful when you want to load data into a sheet from an LINQ query with EF.

```
var ws = new Worksheet("Sheet1");
ws.Populate(ctx.Orders.Where(o => o.Type == "Phone"));
```

I added it to the Worksheet class in case others might find it useful as it would be a common use case.