### PR TITLE
Support date type

### DIFF
--- a/src/Simplexcel/Cells/BuiltInCellFormat.cs
+++ b/src/Simplexcel/Cells/BuiltInCellFormat.cs
@@ -34,5 +34,15 @@
         /// @
         /// </summary>
         public const string Text = "@";
+
+        /// <summary>
+        /// m/d/yyyy h:mm
+        /// </summary>
+        public const string DateAndTime = "m/d/yyyy h:mm";
+
+        /// <summary>
+        /// m/d/yyyy
+        /// </summary>
+        public const string DateOnly = "m/d/yyyy";
     }
 }

--- a/src/Simplexcel/Cells/CellType.cs
+++ b/src/Simplexcel/Cells/CellType.cs
@@ -13,7 +13,11 @@
         /// <summary>
         /// Cell contains a number (may strip leading zeroes but sorts properly)
         /// </summary>
-        Number
-        // TODO: Date
+        Number,
+
+        /// <summary>
+        /// Cell contains a date, must be greater than 01/01/0100
+        /// </summary>
+        Date
     }
 }

--- a/src/Simplexcel/Worksheet.cs
+++ b/src/Simplexcel/Worksheet.cs
@@ -159,6 +159,10 @@ namespace Simplexcel
                     {
                         cell = new Cell(CellType.Number, Convert.ToDecimal(val), BuiltInCellFormat.General);
                     }
+                    else if (val is DateTime)
+                    {
+                        cell = new Cell(CellType.Date, val, BuiltInCellFormat.DateAndTime);
+                    }
                     else
                     {
                         cell = new Cell(CellType.Text, (val ?? String.Empty).ToString(), BuiltInCellFormat.Text);

--- a/src/Simplexcel/XlsxInternal/XlsxWriter.cs
+++ b/src/Simplexcel/XlsxInternal/XlsxWriter.cs
@@ -391,6 +391,15 @@ namespace Simplexcel.XlsxInternal
                             xc.CellType = XlsxCellTypes.Number;
                             xc.Value = ((Decimal)cell.Value.Value).ToString(System.Globalization.CultureInfo.InvariantCulture);
                             break;
+                        case CellType.Date:
+                            xc.CellType = XlsxCellTypes.Number;
+                            if (cell.Value.Value != null)
+#if NETSTANDARD1_3
+                                xc.Value = TicksToOADate(((DateTime)cell.Value.Value).Ticks);
+#else
+                                xc.Value = ((DateTime)cell.Value.Value).ToOADate();
+#endif
+                            break;
                         default:
                             throw new ArgumentException("Unknown Cell Type: " + cell.Value.CellType + " in cell " + cell.Key.ToString() + " of " + sheet.Name);
                     }
@@ -398,6 +407,44 @@ namespace Simplexcel.XlsxInternal
                     rows[cell.Key.Row].Cells.Add(xc);
                 }
                 return rows;
+            }
+
+            private double TicksToOADate(long value)
+            {
+                const long TicksPerMillisecond = 10000;
+                const long TicksPerSecond = TicksPerMillisecond * 1000;
+                const long TicksPerMinute = TicksPerSecond * 60;
+                const long TicksPerHour = TicksPerMinute * 60;
+                const long TicksPerDay = TicksPerHour * 24;
+
+                const int MillisPerSecond = 1000;
+                const int MillisPerMinute = MillisPerSecond * 60;
+                const int MillisPerHour = MillisPerMinute * 60;
+                const int MillisPerDay = MillisPerHour * 24;
+
+                const int DaysPerYear = 365;
+                const int DaysPer4Years = DaysPerYear * 4 + 1;
+                const int DaysPer100Years = DaysPer4Years * 25 - 1;
+                const int DaysPer400Years = DaysPer100Years * 4 + 1;
+                const int DaysTo1899 = DaysPer400Years * 4 + DaysPer100Years * 3 - 367;
+
+                const long DoubleDateOffset = DaysTo1899 * TicksPerDay;
+                const long OADateMinAsTicks = (DaysPer100Years - DaysPerYear) * TicksPerDay;
+
+                if (value == 0)
+                    return 0.0;
+                if (value < TicksPerDay)
+                    value += DoubleDateOffset;
+                if (value < OADateMinAsTicks)
+                    throw new OverflowException("Not a legal OleAut date.");
+
+                long millis = (value - DoubleDateOffset) / TicksPerMillisecond;
+                if (millis < 0)
+                {
+                    long frac = millis % MillisPerDay;
+                    if (frac != 0) millis -= (MillisPerDay + frac) * 2;
+                }
+                return (double)millis / MillisPerDay;
             }
         }
     }


### PR DESCRIPTION
My attempt at resolving https://github.com/mstum/Simplexcel/issues/4.  I'm sure that it can be improved, but I tested using the Populate method and the resulting spreadsheet was correct.

One minor issue was that .NET Standard 1.3 doesn't implement ToOADate method so I had to also add TicksToOADate method.  However, .NET Standard 2.0 does support it so maybe this can be resolved when https://github.com/mstum/Simplexcel/issues/15 is complete?