### PR TITLE
Update cibuild.yml

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -67,4 +67,4 @@ jobs:
           
           # Publish to Nuget.org
           Write-Host "Release build, pushing to Nuget.org: $nupkgPath"
-          dotnet nuget push "$nupkgPath" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
+          dotnet nuget push "$nupkgPath" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json --no-symbols true


### PR DESCRIPTION
Don't publish symbols, as it should now all be in the nupkg/SourceLink.